### PR TITLE
feat: add species data and typed species IDs

### DIFF
--- a/src/game/data/species.ts
+++ b/src/game/data/species.ts
@@ -1,0 +1,7 @@
+export const species = [
+  { id: 'cat', name: 'Cat' },
+  { id: 'dog', name: 'Dog' },
+  { id: 'dragon', name: 'Dragon' },
+] as const;
+
+export type SpeciesId = (typeof species)[number]['id'];

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -4,3 +4,4 @@ export * from './inventory';
 export * from './time';
 export * from './world';
 export * from './meta';
+export type { SpeciesId } from '../data/species';

--- a/src/game/types/pet.ts
+++ b/src/game/types/pet.ts
@@ -1,3 +1,5 @@
+import type { SpeciesId } from '../data/species';
+
 export type PetRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
 
 export type GrowthStage = 'hatchling' | 'juvenile' | 'adult';
@@ -33,7 +35,7 @@ export interface Injury {
 
 export interface Pet {
   /** Identifier for the species */
-  speciesId: string;
+  speciesId: SpeciesId;
   rarity: PetRarity;
   stage: GrowthStage;
   state: PetState;


### PR DESCRIPTION
## Summary
- add simple species data file
- enforce `speciesId` union type on pets
- re-export species id type for easy access

## Testing
- `bun run format`
- `bun run lint`
- `bun run typecheck`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c4741ad08325ab0cbe400da0ed92