### PR TITLE
feat: add world locations and union location types

### DIFF
--- a/src/game/data/locations.ts
+++ b/src/game/data/locations.ts
@@ -1,0 +1,7 @@
+export const locations = [
+  { id: 'home', name: 'Home' },
+  { id: 'park', name: 'Park' },
+  { id: 'shop', name: 'Shop' },
+] as const;
+
+export type LocationId = (typeof locations)[number]['id'];

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -5,3 +5,4 @@ export * from './time';
 export * from './world';
 export * from './meta';
 export type { SpeciesId } from '../data/species';
+export type { LocationId } from '../data/locations';

--- a/src/game/types/world.ts
+++ b/src/game/types/world.ts
@@ -1,4 +1,6 @@
+import type { LocationId } from '../data/locations';
+
 export interface WorldState {
-  location: string;
+  location: LocationId;
   event?: { id: string; progress: number };
 }


### PR DESCRIPTION
## Summary
- add world locations data and LocationId union
- ensure WorldState.location uses LocationId and export type

## Testing
- `bun run format`
- `bun run lint`
- `bun run typecheck`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b3c7c76ad0832596204513c9db8e0b